### PR TITLE
Updated SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,6 @@
 	<groupId>org.destiny.server</groupId>
 	<artifactId>PokemoniumServer</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<properties>
-		<slf4j_version>1.6.4</slf4j_version>
-	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -34,12 +31,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j_version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>${slf4j_version}</version>
+			<version>1.7.21</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.mina</groupId>


### PR DESCRIPTION
Dropped JDK 1.4 support of SLF4J and updated to the latest version 1.7.21

Fixes #2.